### PR TITLE
Keep Streamlit sidebar control visible

### DIFF
--- a/Logout.py
+++ b/Logout.py
@@ -15,17 +15,17 @@ def app():
     """
     st.set_page_config(
         page_title="StAZH Transkribus API",
-        initial_sidebar_state="collapsed",
+        initial_sidebar_state="expanded",
     )
+
+    is_authenticated = st.session_state.get("authenticated", False)
 
     hide_decoration_bar_style = '''
         <style>
             header {visibility: hidden;}
-            [data-testid="collapsedControl"] {
-                display: none;
-            }
         </style>
     '''
+
     st.markdown(hide_decoration_bar_style, unsafe_allow_html=True)
 
     #add_logo("data/loewe.png", height=150)


### PR DESCRIPTION
## Summary
- expand the Streamlit sidebar by default so navigation never collapses automatically
- remove CSS that hid the collapsed sidebar control

## Testing
- not run (explanation: Streamlit UI testing requires interactive credentials)


------
https://chatgpt.com/codex/tasks/task_e_68d65f33a8c88328a607dc3f0d2105e6