### PR TITLE
Hide sidebar collapse controls across selectors

### DIFF
--- a/Logout.py
+++ b/Logout.py
@@ -24,7 +24,10 @@ def app():
         hide_decoration_bar_style = '''
             <style>
                 header {visibility: hidden;}
-                [data-testid="collapsedControl"] {
+                [data-testid="collapsedControl"],
+                [data-testid="stSidebarCollapseButton"],
+                [data-testid="baseButton-toggle"],
+                [data-testid="stBaseButton-headerNoPadding"] {
                     display: none;
                 }
             </style>
@@ -33,6 +36,12 @@ def app():
         hide_decoration_bar_style = '''
             <style>
                 header {visibility: hidden;}
+                [data-testid="collapsedControl"],
+                [data-testid="stSidebarCollapseButton"],
+                [data-testid="baseButton-toggle"],
+                [data-testid="stBaseButton-headerNoPadding"] {
+                    display: none;
+                }
             </style>
         '''
 

--- a/utils/utility_functions.py
+++ b/utils/utility_functions.py
@@ -161,6 +161,12 @@ def set_header(header_name, st):
     hide_decoration_bar_style = '''
         <style>
             header {visibility: hidden;}
+            [data-testid="collapsedControl"],
+            [data-testid="stSidebarCollapseButton"],
+            [data-testid="baseButton-toggle"],
+            [data-testid="stBaseButton-headerNoPadding"] {
+                display: none;
+            }
         </style>
     '''
     st.markdown(hide_decoration_bar_style, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- hide the Streamlit sidebar collapse button by extending the CSS selector list on the login page
- apply the same CSS update in the shared header helper to cover all other pages

## Testing
- streamlit run Logout.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68da47255f9c8328a122dcfe3f140f5a