### PR TITLE
Ensure sidebar controls remain visible

### DIFF
--- a/Logout.py
+++ b/Logout.py
@@ -21,22 +21,14 @@ def app():
     is_authenticated = st.session_state.get("authenticated", False)
 
     if not is_authenticated:
-        hide_decoration_bar_style = '''
+        sidebar_visibility_style = """
             <style>
-                header {visibility: hidden;}
                 [data-testid="collapsedControl"] {
-                    display: none;
+                    display: block !important;
                 }
             </style>
-        '''
-    else:
-        hide_decoration_bar_style = '''
-            <style>
-                header {visibility: hidden;}
-            </style>
-        '''
-
-    st.markdown(hide_decoration_bar_style, unsafe_allow_html=True)
+        """
+        st.markdown(sidebar_visibility_style, unsafe_allow_html=True)
 
     #add_logo("data/loewe.png", height=150)
 

--- a/utils/utility_functions.py
+++ b/utils/utility_functions.py
@@ -158,13 +158,6 @@ def set_header(header_name, st):
         page_title="StAZH Transkribus API",
     )
 
-    hide_decoration_bar_style = '''
-        <style>
-            header {visibility: hidden;}
-        </style>
-    '''
-    st.markdown(hide_decoration_bar_style, unsafe_allow_html=True)
-
     #add_logo("data/loewe.png", height=150)
     st.sidebar.image("res/hoend.png", width=200)
 


### PR DESCRIPTION
## Summary
- remove the injected CSS that hid Streamlit's header and sidebar toggle
- ensure the sidebar toggle control remains available on the login page even before authentication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da67813dbc8328af566174b0fa47f0